### PR TITLE
Issue 5 message relays

### DIFF
--- a/jupyterlab-slurm/slurm.py
+++ b/jupyterlab-slurm/slurm.py
@@ -103,18 +103,18 @@ class SqueueHandler(ShellExecutionHandler):
         # squeue -h automatically removes the header row
         # -o <format string> ensures that the output is in a format expected by the extension
         # Hard-coding this is not great -- ideally we would allow the user to customize this, or have the default output be the user's output
-        data, stderr = await self.run_command('squeue -o "%.18i %.9P %.8j %.8u %.2t %.10M %.6D %R" -h')
-        lines = data.splitlines()
+        stdout, stderr, _ = await self.run_command('squeue -o "%.18i %.9P %.8j %.8u %.2t %.10M %.6D %R" -h')
+        data = stdout.splitlines()
         data_dict = {}
         data_list = []
-        for line in lines:
+        for row in data:
             # maxsplit=7 so we can still display squeue entries with final columns with spaces like the following:
             # (burst_buffer/cray: dws_data_in: DataWarp REST API error: offline namespaces: [34831] - ask a system administrator to consult the dwmd log for more information
-            if len(line.split(maxsplit=7)) == 8:
+            if len(row.split(maxsplit=7)) == 8:
                 # html.escape because some job ID's might have '<'s and similar characters in them.
                 # Also, hypothetically we could be Bobbytable'd without html.escape here,
                 # e.g. if someone had as a jobname '<script>virus.js</script>'.
-                data_list += [[(html.escape(entry)).strip() for entry in line.split(maxsplit=7)]]
+                data_list += [[(html.escape(entry)).strip() for entry in row.split(maxsplit=7)]]
             else:
                 continue
         data_dict['data'] = data_list[:]

--- a/jupyterlab-slurm/slurm.py
+++ b/jupyterlab-slurm/slurm.py
@@ -31,8 +31,8 @@ class ShellExecutionHandler(IPythonHandler):
 class ScancelHandler(ShellExecutionHandler):
     # Add `-H "Authorization: token <token>"` to the curl command for any DELETE request
     async def delete(self):
-        jobID = self.get_body_arguments('jobID')
-        stdout, stderr, returncode = await self.run_command(' '.join(['scancel'] + jobIDs))
+        jobID = self.get_body_arguments('jobID')[0]
+        stdout, stderr, returncode = await self.run_command("scancel " + jobID)
         if stderr:
             responseMessage = stderr
         else:
@@ -45,14 +45,15 @@ class ScancelHandler(ShellExecutionHandler):
 class ScontrolHandler(ShellExecutionHandler):
     # Add `-H "Authorization: token <token>"` to the curl command for any PATCH request
     async def patch(self, command):
-        job_list = ','.join(self.get_body_arguments('jobID'))
-        stdout, stderr, returncode = await self.run_command(' '.join(['scontrol', command, job_list]))
+        jobID = self.get_body_arguments('jobID')[0]
+        stdout, stderr, returncode = await self.run_command("scontrol " + command + " " + jobID)
         if stderr:
             responseMessage = stderr
         else:
             # stdout will be empty on success -- hence the custom success message
-            responseMessage = "Success: " + command + " " + job_list
+            responseMessage = "Success: " + command + " " + jobID
         self.finish({"responseMessage": responseMessage, "returncode": returncode})
+
 
 # sbatch clearly isn't idempotent, and resource ID (i.e. job ID) isn't known when running it, so only POST works for the C in CRUD here, not PUT
 class SbatchHandler(ShellExecutionHandler):

--- a/jupyterlab-slurm/slurm.py
+++ b/jupyterlab-slurm/slurm.py
@@ -51,7 +51,7 @@ class ScontrolHandler(ShellExecutionHandler):
             responseMessage = stderr
         else:
             # stdout will be empty on success -- hence the custom success message
-            responseMessage = "Success: " + command + " " + jobID
+            responseMessage = "Success: scontrol " + command + " " + jobID
         self.finish({"responseMessage": responseMessage, "returncode": returncode})
 
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,8 +1,11 @@
 import { JupyterLabPlugin } from '@jupyterlab/application';
+import 'datatables.net-dt/css/jquery.dataTables.css';
 import 'datatables.net';
+import 'datatables.net-buttons-dt';
 import 'datatables.net-buttons';
 import 'datatables.net-select';
-import 'datatables.net-dt/css/jquery.dataTables.css';
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/dist/js/bootstrap.js';
 import '../style/index.css';
 /**
  * Initialization data for the jupyterlab-slurm extension.

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,10 +20,13 @@ var coreutils_1 = require("@jupyterlab/coreutils");
 var coreutils_2 = require("@phosphor/coreutils");
 var widgets_1 = require("@phosphor/widgets");
 var $ = require("jquery");
+require("datatables.net-dt/css/jquery.dataTables.css");
 require("datatables.net");
+require("datatables.net-buttons-dt");
 require("datatables.net-buttons");
 require("datatables.net-select");
-require("datatables.net-dt/css/jquery.dataTables.css");
+require("bootstrap/dist/css/bootstrap.css");
+require("bootstrap/dist/js/bootstrap.js");
 require("../style/index.css");
 /**
  * The class names for the Slurm extension icon, for launcher and
@@ -31,6 +34,13 @@ require("../style/index.css");
  */
 var SLURM_ICON_CLASS_L = 'jp-NerscLaunchIcon';
 var SLURM_ICON_CLASS_T = 'jp-NerscTabIcon';
+// The number of milliseconds a user must wait in between Refresh requests
+// This limits the number of times squeue is called, in order to avoid
+// overloading the Slurm workload manager
+var USER_SQUEUE_LIMIT = 60000;
+// The interval (milliseconds) in which the queue data automatically reloads
+// by calling squeue
+var AUTO_SQUEUE_LIMIT = 60000;
 var SlurmWidget = /** @class */ (function (_super) {
     __extends(SlurmWidget, _super);
     /* Construct a new Slurm widget. */
@@ -38,8 +48,6 @@ var SlurmWidget = /** @class */ (function (_super) {
         var _this = _super.call(this) || this;
         // The column index of job ID
         _this.JOBID_IDX = 0;
-        console.log('constructor called');
-        console.log('testing!');
         _this.id = 'jupyterlab-slurm';
         _this.title.label = 'Slurm Queue Manager';
         _this.title.closable = true;
@@ -64,7 +72,7 @@ var SlurmWidget = /** @class */ (function (_super) {
             h.appendChild(t);
             head_row.appendChild(h);
         }
-        // reference to this object for use in the jquery func below
+        // reference to this SlurmWidget object for use in the jquery func below
         var self = _this;
         // The base URL that prepends commands -- necessary for hub functionality
         var baseUrl = coreutils_1.PageConfig.getOption('baseUrl');
@@ -108,8 +116,14 @@ var SlurmWidget = /** @class */ (function (_super) {
                 buttons: { buttons: [
                         {
                             text: 'Reload',
+                            name: 'Reload',
                             action: function (e, dt, node, config) {
                                 dt.ajax.reload(null, false);
+                                // Disable the button to avoid overloading Slurm with calls to squeue
+                                // Note, this does not persist across a browser window refresh
+                                dt.button('Reload:name').disable();
+                                // Reactivate Refresh button after USER_SQUEUE_LIMIT milliseconds
+                                setTimeout(function () { dt.button('Reload:name').enable(); }, USER_SQUEUE_LIMIT);
                             }
                         },
                         {
@@ -136,20 +150,6 @@ var SlurmWidget = /** @class */ (function (_super) {
                         {
                             extend: 'selectNone'
                         },
-                        {
-                            text: 'Submit Slurm Script via File Path',
-                            action: function (e, dt, node, config) {
-                                var scriptPath = window.prompt('Enter a Slurm script file path');
-                                self._submit_batch_script_path(scriptPath, dt);
-                                alert(scriptPath);
-                            }
-                        },
-                        {
-                            text: 'Submit Slurm Script via File Contents',
-                            action: function (e, dt, node, config) {
-                                self._submit_batch_script_contents(dt);
-                            }
-                        }
                     ],
                     // https://datatables.net/reference/option/buttons.dom.button
                     // make it easier to identify/grab buttons to change their appearance
@@ -160,6 +160,12 @@ var SlurmWidget = /** @class */ (function (_super) {
                         }
                     } }
             });
+            // Set up and append the alert container -- an area for displaying request response 
+            // messages as color coded, dismissable, alerts
+            var alertContainer = document.createElement('div');
+            alertContainer.setAttribute("id", "alertContainer");
+            alertContainer.classList.add('container', 'alert-container');
+            $('#jupyterlab-slurm').append(alertContainer);
         });
         return _this;
     }
@@ -167,12 +173,10 @@ var SlurmWidget = /** @class */ (function (_super) {
         // reload the data table
         dt.ajax.reload(null, false);
     };
-    SlurmWidget.prototype._submit_request = function (cmd, requestType, body, addJobAlert) {
+    SlurmWidget.prototype._submit_request = function (cmd, requestType, body, jobCount) {
+        if (jobCount === void 0) { jobCount = null; }
         var xhttp = new XMLHttpRequest();
-        if (addJobAlert === true) {
-            this._add_job_completed_alert(xhttp);
-        }
-        ;
+        this._set_job_completed_tasks(xhttp, jobCount);
         // The base URL that prepends the command path -- necessary for hub functionality
         var baseUrl = coreutils_1.PageConfig.getOption('baseUrl');
         // Prepend command with the base URL to yield the final endpoint
@@ -186,53 +190,79 @@ var SlurmWidget = /** @class */ (function (_super) {
     };
     SlurmWidget.prototype._run_on_selected = function (cmd, requestType, dt) {
         // Run CMD on all selected rows, by submitting a unique request for each 
-        // selected row
+        // selected row. Eventually we may want to change the logic for this functionality
+        // such that only one request is made with a list of Job IDs instead of one request
+        // per selected job. Changes will need to be made on the back end for this to work
         var selected_data = dt.rows({ selected: true }).data().toArray();
+        var jobCount = { numJobs: selected_data.length, count: 0 };
         for (var i = 0; i < selected_data.length; i++) {
-            this._submit_request(cmd, requestType, 'jobID=' + selected_data[i][this.JOBID_IDX], false);
+            this._submit_request(cmd, requestType, 'jobID=' + selected_data[i][this.JOBID_IDX], jobCount);
         }
-        this._reload_data_table(dt);
     };
     ;
-    SlurmWidget.prototype._submit_batch_script_path = function (script, dt) {
-        this._submit_request('/sbatch?scriptIs=path', 'POST', 'script=' + encodeURIComponent(script), true);
-        this._reload_data_table(dt);
-    };
-    ;
-    SlurmWidget.prototype._submit_batch_script_contents = function (dt) {
+    // NOTE: Job submission temporarily disabled -- this functions are working and ready to be used and/or refactored
+    // private _submit_batch_script_path(script: string, dt: DataTables.Api) {
+    //   this._submit_request('/sbatch?scriptIs=path', 'POST', 'script=' + encodeURIComponent(script));
+    //   this._reload_data_table(dt);
+    // };
+    // private _submit_batch_script_contents(dt: DataTables.Api) {
+    //   // TODO: clean up
+    //   if ( $('#slurm_script').length == 0) {
+    //    // at the end of the main queue table area, append a prompt message and a form submission area
+    //   $('#queue_wrapper').append('<br><div id="submit_script"><span>'+
+    //                              'Paste in the contents of a Slurm script file and submit them to be run </span><br><br>' +
+    //                              '<textarea id="slurm_script" cols="50" rows="20"></textarea><br>');
+    //   // after the form submission area, insert a submit button and then a cancel button
+    //   $('#slurm_script').after('<div id="slurm_buttons">'+
+    //                             '<button class="button slurm_button" id="submit_button"><span>Submit</span></button>' +
+    //                             '<button class="button slurm_button" id="cancel_button"><span>Cancel</span></button>'+
+    //                             '</div></div>');
+    //   // message above textarea (form submission area), textarea itself, and the two buttons below
+    //   var submitScript = $('#submit_script');
+    //   // do the callback after clicking on the submit button
+    //   $('#submit_button').click( () => {// grab contents of textarea, convert to string, then URI encode them
+    //                                     var scriptContents = encodeURIComponent($('#slurm_script').val().toString()); 
+    //                                     this._submit_request('/sbatch?scriptIs=contents', 'POST', 'script='+scriptContents);
+    //                                     this._reload_data_table(dt);
+    //                                     // remove the submit script prompt area
+    //                                     submitScript.remove();
+    //                                     } );
+    //   // remove the submit script prompt area after clicking the cancel button
+    //   $('#cancel_button').unbind().click( () => {submitScript.remove();} );
+    //   }
+    // };
+    SlurmWidget.prototype._set_job_completed_tasks = function (xhttp, jobCount) {
         var _this = this;
-        // TODO: clean up
-        if ($('#slurm_script').length == 0) {
-            // at the end of the main queue table area, append a prompt message and a form submission area
-            $('#queue_wrapper').append('<br><div id="submit_script"><span>' +
-                'Paste in the contents of a Slurm script file and submit them to be run </span><br><br>' +
-                '<textarea id="slurm_script" cols="50" rows="20"></textarea><br>');
-            // after the form submission area, insert a submit button and then a cancel button
-            $('#slurm_script').after('<div id="slurm_buttons">' +
-                '<button class="button slurm_button" id="submit_button"><span>Submit</span></button>' +
-                '<button class="button slurm_button" id="cancel_button"><span>Cancel</span></button>' +
-                '</div></div>');
-            // message above textarea (form submission area), textarea itself, and the two buttons below
-            var submitScript = $('#submit_script');
-            // do the callback after clicking on the submit button
-            $('#submit_button').click(function () {
-                var scriptContents = encodeURIComponent($('#slurm_script').val().toString());
-                _this._submit_request('/sbatch?scriptIs=contents', 'POST', 'script=' + scriptContents, true);
-                _this._reload_data_table(dt);
-                // remove the submit script prompt area
-                submitScript.remove();
-            });
-            // remove the submit script prompt area after clicking the cancel button
-            $('#cancel_button').unbind().click(function () { submitScript.remove(); });
-        }
-    };
-    ;
-    SlurmWidget.prototype._add_job_completed_alert = function (xhttp) {
-        // TODO: change to _set_job_completed_message(request, message)
         xhttp.onreadystatechange = function () {
-            // alert the user of the job's number after submitting
-            if (xhttp.readyState === xhttp.DONE) {
-                alert("Submitted batch job " + xhttp.responseText.toString());
+            if (xhttp.readyState === xhttp.DONE && xhttp.status == 200) {
+                var response = JSON.parse(xhttp.responseText);
+                var alert_1 = document.createElement('div');
+                if (response.returncode == 0) {
+                    alert_1.classList.add('alert', 'alert-success', 'alert-dismissable', 'fade', 'show');
+                }
+                else {
+                    alert_1.classList.add('alert', 'alert-danger', 'alert-dismissable', 'fade', 'show');
+                }
+                var temp = document.createElement('div');
+                var closeLink = '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>';
+                temp.innerHTML = closeLink;
+                alert_1.appendChild(temp.firstChild);
+                var alertText = document.createTextNode(response.responseMessage);
+                alert_1.appendChild(alertText);
+                $('#alertContainer').append(alert_1);
+                // If all current jobs have finished executing, 
+                // reload the queue (using squeue)
+                if (jobCount) {
+                    // By the nature of javascript's sequential function execution,
+                    // this will not cause a data race (not atomic, but still ok) 
+                    jobCount.count++;
+                    if (jobCount.numJobs == jobCount.count) {
+                        _this._reload_data_table($('#queue').DataTable());
+                    }
+                }
+                else {
+                    _this._reload_data_table($('#queue').DataTable());
+                }
             }
         };
     };
@@ -269,7 +299,7 @@ function activate(app, palette, restorer, launcher) {
                 widget = new SlurmWidget();
                 widget.title.icon = SLURM_ICON_CLASS_T;
                 // Reload table every 60 seconds
-                setInterval(function () { return widget.update(); }, 60000);
+                setInterval(function () { return widget.update(); }, AUTO_SQUEUE_LIMIT);
             }
             if (!tracker.has(widget)) {
                 // Track the state of the widget for later restoration

--- a/package.json
+++ b/package.json
@@ -36,13 +36,17 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
+    "@types/bootstrap": "^4.2.1",
     "@types/datatables.net": "^1.10.12",
     "@types/datatables.net-buttons": "^1.4.0",
     "@types/datatables.net-select": "^1.2.4",
     "@types/jquery": "^3.3.4",
+    "bootstrap": "^4.2.1",
     "datatables.net-buttons-dt": "^1.4.0",
     "datatables.net-dt": "^1.10.19",
-    "datatables.net-select-dt": "^1.2.4"
+    "datatables.net-select-dt": "^1.2.4",
+    "jquery": "^3.3.1",
+    "popper.js": "^1.14.7"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/datatables.net-select": "^1.2.4",
     "@types/jquery": "^3.3.4",
     "bootstrap": "^4.2.1",
-    "datatables.net-buttons-dt": "^1.4.0",
+    "datatables.net-buttons-dt": "^1.5.4",
     "datatables.net-dt": "^1.10.19",
     "datatables.net-select-dt": "^1.2.4",
     "jquery": "^3.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,12 @@ import {
 } from '@phosphor/widgets';
 
 import * as $ from 'jquery';
+import 'datatables.net-dt/css/jquery.dataTables.css';
 import 'datatables.net';
 import 'datatables.net-buttons-dt';
 import 'datatables.net-buttons';
 import 'datatables.net-select';
-import 'datatables.net-dt/css/jquery.dataTables.css';
+
 
 import 'bootstrap/dist/css/bootstrap.css';
 import 'bootstrap/dist/js/bootstrap.js';
@@ -145,10 +146,11 @@ class SlurmWidget extends Widget {
             name: 'Reload',
             action: (e, dt, node, config) => {
               dt.ajax.reload(null, false);
+	      console.log("Reload button clicked");
               // Disable the button to avoid overloading Slurm with calls to squeue
               // TODO: Make sure this refresh limiting functionality persists across
               // a browser window refresh
-              dt.button( 'reload:name' ).disable();
+              dt.button( 'Reload:name' ).disable();
               // Reactivate Refresh button after USER_SQUEUE_LIMIT milliseconds
               setTimeout(function() { dt.button( 'Reload:name' ).enable() }, USER_SQUEUE_LIMIT);
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ const SLURM_ICON_CLASS_T = 'jp-NerscTabIcon';
 // The number of milliseconds a user must wait in between Refresh requests
 // This limits the number of times squeue is called, in order to avoid
 // overloading the Slurm workload manager
-// const USER_SQUEUE_LIMIT = 60000;
+const USER_SQUEUE_LIMIT = 60000;
 // The interval (milliseconds) in which the queue data automatically reloads
 // by calling squeue
 const AUTO_SQUEUE_LIMIT = 60000;
@@ -142,14 +142,15 @@ class SlurmWidget extends Widget {
         buttons: { buttons: [
           {
             text: 'Reload',
+            name: 'Reload',
             action: (e, dt, node, config) => {
               dt.ajax.reload(null, false);
               // Disable the button to avoid overloading Slurm with calls to squeue
               // TODO: Make sure this refresh limiting functionality persists across
               // a browser window refresh
-              // this.disable();
+              dt.button( 'reload:name' ).disable();
               // Reactivate Refresh button after USER_SQUEUE_LIMIT milliseconds
-              // setTimeout(function() { this.enable() }, USER_SQUEUE_LIMIT);
+              setTimeout(function() { dt.button( 'Reload:name' ).enable() }, USER_SQUEUE_LIMIT);
             }
           },
           {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,18 +161,19 @@ class SlurmWidget extends Widget {
           {
             extend: 'selectNone'
           },
-          {
-            text: 'Submit Slurm Script via File Path',
-            action:  (e, dt, node, config) => {
-              var scriptPath = window.prompt('Enter a Slurm script file path');
-              self._submit_batch_script_path(scriptPath, dt)
-            }
-          },
-          {
-            text: 'Submit Slurm Script via File Contents',
-            action: (e, dt, node, config) => {
-              self._submit_batch_script_contents(dt);
-            }
+          // Job submission temporarily disabled
+          // {
+          //   text: 'Submit Slurm Script via File Path',
+          //   action:  (e, dt, node, config) => {
+          //     var scriptPath = window.prompt('Enter a Slurm script file path');
+          //     self._submit_batch_script_path(scriptPath, dt)
+          //   }
+          // },
+          // {
+          //   text: 'Submit Slurm Script via File Contents',
+          //   action: (e, dt, node, config) => {
+          //     self._submit_batch_script_contents(dt);
+          //   }
           }
        
         ],
@@ -227,38 +228,39 @@ class SlurmWidget extends Widget {
     this._reload_data_table(dt);
   };
 
-  private _submit_batch_script_path(script: string, dt: DataTables.Api) {
-    this._submit_request('/sbatch?scriptIs=path', 'POST', 'script=' + encodeURIComponent(script));
-    this._reload_data_table(dt);
-  };
+  // NOTE: Job submission temporarily disabled -- this functions are working and ready to be used and/or refactored
+  // private _submit_batch_script_path(script: string, dt: DataTables.Api) {
+  //   this._submit_request('/sbatch?scriptIs=path', 'POST', 'script=' + encodeURIComponent(script));
+  //   this._reload_data_table(dt);
+  // };
 
-  private _submit_batch_script_contents(dt: DataTables.Api) {
-    // TODO: clean up
-    if ( $('#slurm_script').length == 0) {
-     // at the end of the main queue table area, append a prompt message and a form submission area
-    $('#queue_wrapper').append('<br><div id="submit_script"><span>'+
-                               'Paste in the contents of a Slurm script file and submit them to be run </span><br><br>' +
-                               '<textarea id="slurm_script" cols="50" rows="20"></textarea><br>');
-    // after the form submission area, insert a submit button and then a cancel button
-    $('#slurm_script').after('<div id="slurm_buttons">'+
-                              '<button class="button slurm_button" id="submit_button"><span>Submit</span></button>' +
-                              '<button class="button slurm_button" id="cancel_button"><span>Cancel</span></button>'+
-                              '</div></div>');
-    // message above textarea (form submission area), textarea itself, and the two buttons below
-    var submitScript = $('#submit_script');
-    // do the callback after clicking on the submit button
-    $('#submit_button').click( () => {// grab contents of textarea, convert to string, then URI encode them
-                                      var scriptContents = encodeURIComponent($('#slurm_script').val().toString()); 
-                                      this._submit_request('/sbatch?scriptIs=contents', 'POST', 'script='+scriptContents);
-                                      this._reload_data_table(dt);
-                                      // remove the submit script prompt area
-                                      submitScript.remove();
-                                      } );
-    // remove the submit script prompt area after clicking the cancel button
-    $('#cancel_button').unbind().click( () => {submitScript.remove();} );
+  // private _submit_batch_script_contents(dt: DataTables.Api) {
+  //   // TODO: clean up
+  //   if ( $('#slurm_script').length == 0) {
+  //    // at the end of the main queue table area, append a prompt message and a form submission area
+  //   $('#queue_wrapper').append('<br><div id="submit_script"><span>'+
+  //                              'Paste in the contents of a Slurm script file and submit them to be run </span><br><br>' +
+  //                              '<textarea id="slurm_script" cols="50" rows="20"></textarea><br>');
+  //   // after the form submission area, insert a submit button and then a cancel button
+  //   $('#slurm_script').after('<div id="slurm_buttons">'+
+  //                             '<button class="button slurm_button" id="submit_button"><span>Submit</span></button>' +
+  //                             '<button class="button slurm_button" id="cancel_button"><span>Cancel</span></button>'+
+  //                             '</div></div>');
+  //   // message above textarea (form submission area), textarea itself, and the two buttons below
+  //   var submitScript = $('#submit_script');
+  //   // do the callback after clicking on the submit button
+  //   $('#submit_button').click( () => {// grab contents of textarea, convert to string, then URI encode them
+  //                                     var scriptContents = encodeURIComponent($('#slurm_script').val().toString()); 
+  //                                     this._submit_request('/sbatch?scriptIs=contents', 'POST', 'script='+scriptContents);
+  //                                     this._reload_data_table(dt);
+  //                                     // remove the submit script prompt area
+  //                                     submitScript.remove();
+  //                                     } );
+  //   // remove the submit script prompt area after clicking the cancel button
+  //   $('#cancel_button').unbind().click( () => {submitScript.remove();} );
     
-    }
-  };
+  //   }
+  // };
 
   private _set_job_completed_alert(xhttp: XMLHttpRequest) {
     xhttp.onreadystatechange = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,18 +304,16 @@ class SlurmWidget extends Widget {
         // If all current jobs have finished executing, 
         // reload the queue (using squeue)
         if (jobCount) {
+          // By the nature of javascript's sequential function execution,
+          // this will not cause a data race (not atomic, but still ok) 
+          jobCount.count++;
+          console.log("numjobs: ", jobCount.numJobs);
+          console.log("count: ", jobCount.count);
+          console.log("result: ", jobCount.numJobs == jobCount.count);
           if (jobCount.numJobs == jobCount.count) {
-	    console.log("ENTERED!");
+      	    console.log("ENTERED!");
             this._reload_data_table($('#queue').DataTable());
             console.log("Finished running selected jobs");
-          }
-          else {
-            // By the nature of javascript's sequential function execution,
-            // this will not cause a data race (not atomic, but still ok) 
-            jobCount.count++;
-	    console.log("numjobs: ", jobCount.numJobs);
-	    console.log("count: ", jobCount.count);
-	    console.log("result: ", jobCount.numJobs == jobCount.count);
           }
         }
         else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,6 @@ class SlurmWidget extends Widget {
   /* Construct a new Slurm widget. */
   constructor() {
     super();
-    console.log('constructor called');
-    console.log('testing!');
     this.id = 'jupyterlab-slurm';
     this.title.label = 'Slurm Queue Manager';
     this.title.closable = true;
@@ -146,10 +144,8 @@ class SlurmWidget extends Widget {
             name: 'Reload',
             action: (e, dt, node, config) => {
               dt.ajax.reload(null, false);
-	      console.log("Reload button clicked");
               // Disable the button to avoid overloading Slurm with calls to squeue
-              // TODO: Make sure this refresh limiting functionality persists across
-              // a browser window refresh
+              // Note, this does not persist across a browser window refresh
               dt.button( 'Reload:name' ).disable();
               // Reactivate Refresh button after USER_SQUEUE_LIMIT milliseconds
               setTimeout(function() { dt.button( 'Reload:name' ).enable() }, USER_SQUEUE_LIMIT);
@@ -238,13 +234,14 @@ class SlurmWidget extends Widget {
 
   private _run_on_selected(cmd: string, requestType: string, dt: DataTables.Api) {
     // Run CMD on all selected rows, by submitting a unique request for each 
-    // selected row
+    // selected row. Eventually we may want to change the logic for this functionality
+    // such that only one request is made with a list of Job IDs instead of one request
+    // per selected job. Changes will need to be made on the back end for this to work
 
     let selected_data = dt.rows( { selected: true } ).data().toArray();
     let jobCount = { numJobs: selected_data.length, count: 0 };
     for (let i = 0; i < selected_data.length; i++) {
        this._submit_request(cmd, requestType, 'jobID='+selected_data[i][this.JOBID_IDX], jobCount);
-       console.log("Finished job: ", i);
     }
     
     
@@ -310,18 +307,12 @@ class SlurmWidget extends Widget {
           // By the nature of javascript's sequential function execution,
           // this will not cause a data race (not atomic, but still ok) 
           jobCount.count++;
-          console.log("numjobs: ", jobCount.numJobs);
-          console.log("count: ", jobCount.count);
-          console.log("result: ", jobCount.numJobs == jobCount.count);
           if (jobCount.numJobs == jobCount.count) {
-      	    console.log("ENTERED!");
             this._reload_data_table($('#queue').DataTable());
-            console.log("Finished running selected jobs");
           }
         }
         else {
            this._reload_data_table($('#queue').DataTable());
-           console.log("Finished running selected jobs");
         }
       }
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,7 +304,8 @@ class SlurmWidget extends Widget {
         // If all current jobs have finished executing, 
         // reload the queue (using squeue)
         if (jobCount) {
-          if (jobCount.numJobs === jobCount.count) {
+          if (jobCount.numJobs == jobCount.count) {
+	    console.log("ENTERED!");
             this._reload_data_table($('#queue').DataTable());
             console.log("Finished running selected jobs");
           }
@@ -312,6 +313,9 @@ class SlurmWidget extends Widget {
             // By the nature of javascript's sequential function execution,
             // this will not cause a data race (not atomic, but still ok) 
             jobCount.count++;
+	    console.log("numjobs: ", jobCount.numJobs);
+	    console.log("count: ", jobCount.count);
+	    console.log("result: ", jobCount.numJobs == jobCount.count);
           }
         }
         else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
 
 import * as $ from 'jquery';
 import 'datatables.net';
+import 'datatables.net-buttons-dt';
 import 'datatables.net-buttons';
 import 'datatables.net-select';
 import 'datatables.net-dt/css/jquery.dataTables.css';
@@ -174,7 +175,7 @@ class SlurmWidget extends Widget {
           //   action: (e, dt, node, config) => {
           //     self._submit_batch_script_contents(dt);
           //   }
-          }
+	  // }
        
         ],
         // https://datatables.net/reference/option/buttons.dom.button
@@ -268,10 +269,10 @@ class SlurmWidget extends Widget {
         let response = JSON.parse(xhttp.responseText);
         let alert = document.createElement('div');
         if (response.returncode == 0) {
-          alert.classList.add('alert', 'alert-success', 'alert-dismissable');
+          alert.classList.add('alert', 'alert-success', 'alert-dismissable', 'fade', 'show');
         }
         else {
-          alert.classList.add('alert', 'alert-danger', 'alert-dismissable');
+          alert.classList.add('alert', 'alert-danger', 'alert-dismissable', 'fade', 'show');
         }
         let temp = document.createElement('div');
         let closeLink = '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>';

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ class SlurmWidget extends Widget {
       head_row.appendChild(h);
     }
 
-    // reference to this object for use in the jquery func below
+    // reference to this SlurmWidget object for use in the jquery func below
     var self = this;
     // The base URL that prepends commands -- necessary for hub functionality
     var baseUrl = PageConfig.getOption('baseUrl');
@@ -208,6 +208,12 @@ class SlurmWidget extends Widget {
       alertContainer.setAttribute("id", "alertContainer");
       alertContainer.classList.add('container', 'alert-container');
       $('#jupyterlab-slurm').append(alertContainer);
+
+
+      $(document).ajaxStop(function() { 
+        $('#queue').DataTable().ajax.reload(null, false));
+        console.log("All ajax jobs complete!");
+      });
 
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import 'datatables.net';
 import 'datatables.net-buttons';
 import 'datatables.net-select';
 import 'datatables.net-dt/css/jquery.dataTables.css';
+import 'bootstrap.js';
 
 import '../style/index.css';
 
@@ -183,6 +184,14 @@ class SlurmWidget extends Widget {
           }
         }  }
       });
+
+      let alertContainer = document.createElement('div', { class: "container" });
+      let testAlert = document.createElement('div', { class: "alert alert-success" });
+      let alertText = document.createTextNode("This is a test alert!");
+      testAlert.appendChild(alertText);
+      alertContainer.appendChild(testAlert);
+
+      $('#queue_wrapper').appendChild(alertContainer);
 
 
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,9 @@ import 'datatables.net';
 import 'datatables.net-buttons';
 import 'datatables.net-select';
 import 'datatables.net-dt/css/jquery.dataTables.css';
-import 'bootstrap.js';
+
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/dist/js/bootstrap.js';
 
 import '../style/index.css';
 
@@ -185,13 +187,22 @@ class SlurmWidget extends Widget {
         }  }
       });
 
-      let alertContainer = document.createElement('div', { class: "container" });
-      let testAlert = document.createElement('div', { class: "alert alert-success" });
+      let alertContainer = document.createElement('div');
+      alertContainer.classList.add('container');
+
+      let testAlert = document.createElement('div');
+      alertContainer.classList.add('alert', 'alert-success');
+
+      let temp = document.createElement('div');
+      let closeLink = '<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>';
+      temp.innerHTML = closeLink;
+      testAlert.appendChild(temp.firstChild);
+
       let alertText = document.createTextNode("This is a test alert!");
       testAlert.appendChild(alertText);
       alertContainer.appendChild(testAlert);
 
-      $('#queue_wrapper').append(alertContainer);
+      $('#jupyterlab-slurm').append(alertContainer);
 
 
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,10 @@ class SlurmWidget extends Widget {
     // Render table using DataTable's API
     $(document).ready(function() {
       $('#queue').DataTable( {
-        ajax: URLExt.join(baseUrl, '/squeue'),
+        ajax: {
+          url: URLExt.join(baseUrl, '/squeue'),
+          global: false
+        },
         select: {
           style: 'os',
         },
@@ -147,9 +150,9 @@ class SlurmWidget extends Widget {
               // Disable the button to avoid overloading Slurm with calls to squeue
               // TODO: Make sure this refresh limiting functionality persists across
               // a browser window refresh
-              this.disable();
+              // this.disable();
               // Reactivate Refresh button after USER_SQUEUE_LIMIT milliseconds
-              setTimeout(function() { this.enable() }, USER_SQUEUE_LIMIT);
+              // setTimeout(function() { this.enable() }, USER_SQUEUE_LIMIT);
             }
           },
           {
@@ -210,10 +213,10 @@ class SlurmWidget extends Widget {
       $('#jupyterlab-slurm').append(alertContainer);
 
 
-      $(document).ajaxStop(function() { 
-        $('#queue').DataTable().ajax.reload(null, false));
-        console.log("All ajax jobs complete!");
-      });
+      // $(document).ajaxStop(function() { 
+      //   $('#queue').DataTable().ajax.reload(null, false);
+      //   console.log("All ajax jobs complete!");
+      // });
 
     });
   }
@@ -248,7 +251,13 @@ class SlurmWidget extends Widget {
        console.log("Finished job: ", i);
     }
     console.log("Finished running selected jobs");
-    this._reload_data_table(dt);
+
+    $(document).ajaxStop(function() { 
+      $('#queue').DataTable().ajax.reload(null, false);
+      console.log("All ajax jobs complete!");
+    });
+    
+    // this._reload_data_table(dt);
   };
 
   // NOTE: Job submission temporarily disabled -- this functions are working and ready to be used and/or refactored

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ class SlurmWidget extends Widget {
       testAlert.appendChild(alertText);
       alertContainer.appendChild(testAlert);
 
-      $('#queue_wrapper').appendChild(alertContainer);
+      $('#queue_wrapper').append(alertContainer);
 
 
       });

--- a/style/index.css
+++ b/style/index.css
@@ -32,6 +32,9 @@
   margin-bottom: .25em;
   font-size: .9em;
   /* vertical-align: middle; */
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 /* basically all of the substance/content of the widget */

--- a/style/index.css
+++ b/style/index.css
@@ -19,8 +19,8 @@
 /* The message alerts container */
 .alert-container {
   margin-top: 20px;
-  margin-left: 10px;
-  width: 70%;
+  margin-left: 20px;
+  width: 50%;
 }
 
 

--- a/style/index.css
+++ b/style/index.css
@@ -16,6 +16,18 @@
   background-image: url("nersc_icon_small.png");
 }
 
+/* The message alerts container */
+.alert-container {
+  margin-top: 20px;
+  margin-left: 10px;
+  width: 50%;
+}
+
+/* The alert itself -- this class is originally defined by bootstrap */
+.alert {
+  height: 3em;
+}
+
 /* basically all of the substance/content of the widget */
 #queue_wrapper {
   margin-left: 3em;
@@ -146,7 +158,6 @@ table.dataTable.display tbody tr.selected > .sorting_3 {
 .dataTables_wrapper .dataTables_paginate .paginate_button.current,
 .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
   background-color: var(--jp-layout-color0);
-  /* what is wrong with these dataTables people?! */
   color: var(--jp-ui-font-color0) !important;
   background-image: none;
 }

--- a/style/index.css
+++ b/style/index.css
@@ -20,12 +20,18 @@
 .alert-container {
   margin-top: 20px;
   margin-left: 10px;
-  width: 50%;
+  width: 70%;
 }
+
 
 /* The alert itself -- this class is originally defined by bootstrap */
 .alert {
-  height: 3em;
+  height: 1.5em;
+  line-height: 1.4;
+  padding: 0px 7.5px 0px 15px;
+  margin-bottom: .25em;
+  font-size: .9em;
+  /* vertical-align: middle; */
 }
 
 /* basically all of the substance/content of the widget */


### PR DESCRIPTION
Changes in this branch:
- Fixed a couple bugs in the back end that were causing invalid responses to the front end
- Set up back end to return Slurm's stdout/stderr for each request
- Implemented functionality on the front end to receive the Slurm stdout/stderr messages, and display 
   the messages below the queue using the Bootstrap Alerts library.
- Temporarily disabled job submission
- Limited number of "Reload" button clicks to once per minute (or USER_SQUEUE_LIMIT if changed)
- Fixed a bug in the front end: the table was reloading before all requested actions had completed. 
  This has been fixed.
- Refactoring and clean up of both front and back end
