### PR TITLE
Use directory currently open in JupyterLab file browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@jupyterlab/application": "^1.0",
     "@jupyterlab/apputils": "^1.0",
     "@jupyterlab/coreutils": "^3.0",
+    "@jupyterlab/filebrowser": "^1.0",
     "@jupyterlab/launcher": "^1.0",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",


### PR DESCRIPTION
Backend and frontend changes to make the default output directory (as well as the directory from which the script is run) to be the same as the directory currently open in the JupyterLab file browser.