### PR TITLE
Update index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,12 +274,12 @@ class SlurmWidget extends Widget {
                 <div class="form-group">
                   <label for="path">Enter a file path containing a batch script</label>
                   <input type="text" name="path" id="batchPath" class="form-control">
-                  <input type="submit" class="btn btn-primary" id="submitPath">
+                  <input type="submit" value="Submit" class="btn btn-primary" id="submitPath">
                 </div>
                 <div class="form-group">
                   <label for="script">Enter a new batch script</label>
                   <textarea name="script" id="batchScript" rows="10" class="form-control"></textarea>
-                  <input type="submit" class="btn btn-primary" id="submitScript">
+                  <input type="submit" value="Submit" class="btn btn-primary" id="submitScript">
                   <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                 </div>
               </div>


### PR DESCRIPTION
Adds a value of Submit to the batch job submit buttons. Default appearance on Firefox (68.0.1) is "Submit Query", which is confusing for a user. This PR adds an explicit value of "Submit", so behaviour on Firefox is aligned with the default behaviour on Safari (12.1.2) and Chrome (76.0.3809.132) on Mac OSX, which was "Submit" anyway.