### PR TITLE
Enable user view when launched via JupyterHub

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ class SlurmWidget extends Widget {
     // used in the initComplete method once this request completes,
     // and after the table is fully initialized.
     let userRequest = $.ajax({
-      url: '/user',
+      url: window.location.origin + baseUrl + 'user',
       success: function(result) {
         self.user = result;
         console.log("user: ", self.user);


### PR DESCRIPTION
Fix for #23 . User view is now enabled when JuptyerLab is launched through the Hub. Previously, method to get username was 404 through the Hub. This fix is tested on a local deployment. Please test on NERSC and/or other deployments as mileage might vary.