### PR TITLE
Allow multiline alerts

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -30,15 +30,15 @@
 
 /* The alert itself -- this class is originally defined by bootstrap */
 .alert {
-  height: 1.5em;
+  /* height: 1.5em; */
   line-height: 1.4;
   padding: 0px 7.5px 0px 15px;
   margin-bottom: .25em;
   font-size: .9em;
-  /* vertical-align: middle; */
-  text-overflow: ellipsis;
+  vertical-align: middle; 
+  /* text-overflow: ellipsis;
   white-space: nowrap;
-  overflow: hidden;
+  overflow: hidden; */
 }
 
 .toggle-switch {


### PR DESCRIPTION
This PR addresses #24 . The explicit height resulted in a box that was too thin for a single line alert. The explicit no wrap and hidden overflow prevented multi line errors.
<img width="1065" alt="Screenshot 2019-09-19 at 20 10 49" src="https://user-images.githubusercontent.com/5872125/65270051-ab3c5000-db1a-11e9-9e97-c86abb6904a2.png">
